### PR TITLE
feat: Firefox 지원 추가

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,7 +30,8 @@
         }
     ],
     "background": {
-        "service_worker": "scripts/background.js"
+        "service_worker": "scripts/background.js",
+        "scripts": ["scripts/background.js"]
     },
     "web_accessible_resources": [
         {


### PR DESCRIPTION
Firefox는 background.service_worker를 지원하지 않습니다. Chromium 121 이상에서 background.scripts가 무시되기에 둘 다 있어도 문제가 생기지 않습니다.

참고: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support